### PR TITLE
README example code update: Message initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ override func viewDidLoad() {
 override func viewDidAppear(animated: Bool) {
     super.viewDidAppear(animated)
 
-    let message = Message(text: "Hello there")
-
+    let message = Message(text: "Hello World", displayDuration: 3, actionKey: "tapAction", isError: false)
+    
     NotificationBanner.showMessage(message)
 }
 


### PR DESCRIPTION
The simple text init for Message does not set actionKey, which is required for tapping the banner to work.  For users coming to use this repo, the example code should work.
